### PR TITLE
Change protected authorize() method to public

### DIFF
--- a/lib/class.plugify-gform-braintree.php
+++ b/lib/class.plugify-gform-braintree.php
@@ -61,7 +61,7 @@ final class Plugify_GForm_Braintree extends GFPaymentAddOn {
 	* @since 1.0
 	* @return void
 	*/
-	protected function authorize( $feed, $submission_data, $form, $entry ) {
+	public function authorize( $feed, $submission_data, $form, $entry ) {
 
 		// Prepare authorization response payload
 		$authorization = array(


### PR DESCRIPTION
Though I disagree with the change, GF has made all protected methods in their add on framework public, and now throws notices for add-ons that have protected methods.  This occurred in 1.9.  This fixes the notice.