### PR TITLE
fix: check for Braintree class before including library

### DIFF
--- a/gravity-forms-braintree.php
+++ b/gravity-forms-braintree.php
@@ -22,8 +22,9 @@ if( is_callable( array( 'GFForms', 'include_payment_addon_framework' ) ) ) {
 	GFForms::include_payment_addon_framework();
 
 	// Require Braintree Payments core
-	require_once $path . 'lib/Braintree.php';
-
+  if ( ! class_exists( 'Braintree' ) ) {
+	 require_once $path . 'lib/Braintree.php';
+  }
 	// Require plugin entry point
 	require_once $path . 'lib/class.plugify-gform-braintree.php';
 


### PR DESCRIPTION
When using other plugins which include the Braintree library, conflicts can occur.
The change here checks for the Class before including.
