### PR TITLE
add gform_braintree_payload filter

### DIFF
--- a/gravity-forms-braintree.php
+++ b/gravity-forms-braintree.php
@@ -4,7 +4,7 @@ Plugin Name: Gravity Forms Braintree Add-On
 Plugin URI: http://plugify.io/
 Description: Allow your customers to purchase goods and services through Gravity Forms via Braintree Payments
 Author: Plugify
-Version: 1.1.1
+Version: 1.1.2
 Author URI: http://plugify.io
 */
 

--- a/lib/class.plugify-gform-braintree.php
+++ b/lib/class.plugify-gform-braintree.php
@@ -43,7 +43,7 @@ final class Plugify_GForm_Braintree extends GFPaymentAddOn {
 
 	/**
 	* After form has been submitted, send CC details to Braintree and ensure the card is going to work
-	* If not, void the validation result (processed elsewhere) and have the submit the form again
+	* If not, void the validation result (processed elsewhere) and have them submit the form again
 	*
 	* @param $feed - Current configured payment feed
 	* @param $submission_data - Contains form field data submitted by the user as well as payment information (i.e. payment amount, setup fee, line items, etc...)
@@ -85,7 +85,22 @@ final class Plugify_GForm_Braintree extends GFPaymentAddOn {
 			$card_number = str_replace( array( '-', ' ' ), '', $submission_data['card_number'] );
 
 			// Prepare Braintree payload
-			$args = array(
+            // Use filter gform_braintree_payload to modify the default payload
+            // Example:
+            //
+            // add_filter( 'gform_braintree_payload', 'example_callback', 10, 3 );
+            // function example_callback( $args, $entry, $form ) {
+            // // check for a field named "Email"
+            // foreach ( $form['fields'] as $field ) {
+            //     if ( 'Email' == $field->label ) {
+            //         $args['customer']['email'] = $entry[$field->id];
+            //     }
+            // }
+            // 
+            // return $args;
+            // }
+            //
+			$args = apply_filters( 'gform_braintree_payload', array(
 				'amount' => $submission_data['payment_amount'],
 				'creditCard' => array(
 					'number' => $card_number,
@@ -102,7 +117,7 @@ final class Plugify_GForm_Braintree extends GFPaymentAddOn {
 					'locality' => $submission_data['city'],
 					'postalCode' => $submission_data['zip']
 					)
-			);
+			), $entry, $form );
 
 			try {
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=hello
 Tags: credit card,braintree,gravity form,payment
 Requires at least: 3.8
 Tested up to: 3.9
-Stable tag: 1.1.1
+Stable tag: 1.1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Allows users to specify more information to add to the payload, including the email address field, which is required if payment receipts are enabled.

If payment receipts are enabled but the email address is not passed to Braintree, the customer sees the error “Your card could not be billed. Please ensure the details you entered are correct and try again.”

Here’s a sample filter that adds email and first/last names:

```
add_filter( 'gform_braintree_payload', 'my_braintree_add_email', 10, 3 );
function my_braintree_add_email( $args, $entry, $form ) {
    foreach ( $form['fields'] as $field ) {
        if ( 'Email' == $field->label ) {
            // field named "Email"
            $args['customer']['email'] = $entry[$field->id];
        } elseif ( 'name' == $field->type ) {
            // field using the "name" type
            foreach ( $field['inputs'] as $input ) {
                if ( 'First' == $input['label'] ) {
                    $args['customer']['firstName'] = $entry[$input['id']];
                    $args['billing']['firstName'] = $entry[$input['id']];
                } elseif ( 'Last' == $input['label'] ) {
                    $args['customer']['lastName'] = $entry[$input['id']];
                    $args['billing']['lastName'] = $entry[$input['id']];
                }
            }
        }
    }

    return $args;
}
```